### PR TITLE
Fix yum-builddep command to install dependencies

### DIFF
--- a/build_cpython_linux.rst
+++ b/build_cpython_linux.rst
@@ -25,7 +25,7 @@ Get tools and dependencies
     * version based on ``yum``::
 
         $ sudo yum install -y yum-utils
-        $ sudo yum-buildep -y python3
+        $ sudo yum-builddep -y python3
 
     * version based on ``dnf``::
 


### PR DESCRIPTION
Fixed the yum-builddep command to install cpython dependencies in yum based environment.